### PR TITLE
Fix the decoder which expects a string.

### DIFF
--- a/lib/logstash/codecs/pnda-avro.rb
+++ b/lib/logstash/codecs/pnda-avro.rb
@@ -70,7 +70,7 @@ class LogStash::Codecs::PNDAAvro < LogStash::Codecs::Base
 
   public
   def decode(data)
-    datum = StringIO.new(String.from_java_bytes(data))
+    datum = StringIO.new(data)
     decoder = Avro::IO::BinaryDecoder.new(datum)
     datum_reader = Avro::IO::DatumReader.new(@schema)
     yield LogStash::Event.new(datum_reader.read(decoder))

--- a/spec/codecs/pnda-avro_spec.rb
+++ b/spec/codecs/pnda-avro_spec.rb
@@ -24,9 +24,8 @@ describe LogStash::Codecs::PNDAAvro do
       buffer = StringIO.new
       encoder = Avro::IO::BinaryEncoder.new(buffer)
       dw.write(test_event.to_hash, encoder)
-      payload = buffer.string.to_java_bytes
 
-      subject.decode(payload) do |event|
+      subject.decode(buffer.string) do |event|
         insist { event.is_a? LogStash::Event }
         insist { event.get("foo") } == test_event.get("foo")
         insist { event.get("bar") } == test_event.get("bar")


### PR DESCRIPTION
According to the Kafka input plugin, the data passed to the decoder is
of a string type.
See
https://github.com/logstash-plugins/logstash-input-kafka/blob/cebebc38d3168032ea8c0b0b1f7b29aec6eb00a4/lib/logstash/inputs/kafka.rb#L252